### PR TITLE
Permit authentication using ~/.config/gcloud/application_default_credentials.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The file you download is the one provided in the `path` property.
   If you have [`gcloud`][gcloud] setup you can piggyback on the account
   currently set as active for the user running Chef.
 
+- `applicationdefaultcredentials`
+  Same as above. See `gcloud auth application-default login --help` for more
+  information
+
 	_Warning! Please be aware that the account is subject to whichever account is
 	set as active on `gcloud` tool, so the results will not be always consistent
 	if they change under Chef by the user._

--- a/resources/credential.rb
+++ b/resources/credential.rb
@@ -38,6 +38,10 @@ module Google
         new_resource.__auth ::Google::Authorization.new.from_user_credential!
       end
 
+      action :applicationdefaultcredentials do
+        new_resource.__auth ::Google::Authorization.new.from_application_default_credentials!
+      end
+
       action :nothing do
         raise 'An action for a provider is required: service_account'
       end

--- a/resources/credential.rb
+++ b/resources/credential.rb
@@ -35,7 +35,7 @@ module Google
       end
 
       action :defaultuseraccount do
-        __auth ::Google::Authorization.new.from_user_credential!
+        new_resource.__auth ::Google::Authorization.new.from_user_credential!
       end
 
       action :nothing do

--- a/resources/google/authorization.rb
+++ b/resources/google/authorization.rb
@@ -97,7 +97,11 @@ module Google
     end
 
     def from_application_default_credentials!
-      raise NotImplementedError, ':application_default_credentials'
+      Google::Ruby.ensure_two!
+      hash = make_secrets_hash(application_default_credentials)
+      @authorization = Google::APIClient::ClientSecrets.new(hash)
+                                                       .to_authorization
+      self
     end
 
     private
@@ -116,6 +120,12 @@ module Google
       req['Authorization'] = auth[:authorization]
       req.token = auth[:authorization].split(' ')[1]
       req
+    end
+
+    def application_default_credentials
+      JSON.parse(
+        File.read(File.join(ENV['HOME'], '.config', 'gcloud', 'application_default_credentials.json'))
+      )
     end
 
     def credentials


### PR DESCRIPTION
Thanks for all your work on these chef recipes.

I don't think `~/.config/gcloud/credentials` is created by gcloud(1) anymore. I've implemented this new action so I can test using chef-solo when authenticated to the GCP API using my normal user.

Tested using:
chef client: 13.4.19
gcloud: 180.0.0

If you'd like any changes then please let me know.

Thanks again,